### PR TITLE
Improve Cassiope app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Cassiope-3
+# Cassiope
+
+Application de rédaction d'articles multi‑agents en français. Cassiope utilise l'SDK OpenAI Agents et Streamlit pour orchestrer différents agents GPT‑4o.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Utilisation
+
+Exécutez l'interface Streamlit :
+
+```bash
+streamlit run app.py
+```
+
+Ajoutez vos clés API OpenAI et Fal.ai dans le panneau latéral puis suivez les étapes.
+
+Vous pouvez également personnaliser le ton et la longueur des articles ainsi que modifier les instructions de chaque agent via l'éditeur de prompts.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,112 @@
+import streamlit as st
+from cassiope import config, workflow
+from cassiope import prompts
+
+st.set_page_config(page_title="Cassiope", page_icon="✨")
+
+cfg = config.load_config()
+
+page = st.sidebar.selectbox("Page", ["Workflow", "Éditeur de Prompts"])
+prompts_data = prompts.load_prompts()
+
+st.title("Cassiope – Rédaction d’Articles Intelligente")
+import os
+
+openai_key = st.sidebar.text_input("Clé API OpenAI", value=cfg.get("OPENAI_API_KEY"), type="password")
+fal_key = st.sidebar.text_input("Clé API Fal.ai", value=cfg.get("FAL_API_KEY"), type="password")
+tone_options = ["professionnel", "analytique", "inspirationnel"]
+tone = st.sidebar.selectbox(
+    "Ton de l’article",
+    tone_options,
+    index=tone_options.index(cfg.get("tone", "professionnel")),
+)
+length_options = ["court", "moyen", "long"]
+length = st.sidebar.selectbox(
+    "Longueur",
+    length_options,
+    index=length_options.index(cfg.get("length", "moyen")),
+)
+
+if st.sidebar.button("Enregistrer"):
+    cfg["OPENAI_API_KEY"] = openai_key
+    cfg["FAL_API_KEY"] = fal_key
+    cfg["tone"] = tone
+    cfg["length"] = length
+    os.environ["OPENAI_API_KEY"] = openai_key
+    os.environ["FAL_API_KEY"] = fal_key
+    config.save_config(cfg)
+    st.sidebar.success("Paramètres sauvegardés")
+
+if page == "Workflow":
+    st.header("Phase 1 : Raffinement du Thème et du Titre")
+    theme = st.text_input("Thème initial")
+    if st.button("Générer des titres") and theme:
+        titres = workflow.refine_title(theme)
+        chosen_title = st.radio("Choisissez un titre", titres)
+        st.session_state["title"] = chosen_title
+        workflow.set_title(chosen_title)
+
+    st.header("Phase 2 : Recherche et Planification")
+    if st.session_state.get("title"):
+        if st.button("Lancer la recherche"):
+            research_results = workflow.research(st.session_state["title"])
+            st.session_state["research"] = research_results
+        if st.session_state.get("research"):
+            plans = workflow.generate_plans(st.session_state["title"], st.session_state["research"])
+            chosen_plan = st.selectbox("Choisissez un plan", plans)
+            st.session_state["plan"] = chosen_plan
+
+    st.header("Phase 3 : Rédaction Initiale")
+    if st.session_state.get("plan"):
+        if st.button("Rédiger l’article"):
+            article_v1 = workflow.draft_article(
+                st.session_state["title"], st.session_state["research"], st.session_state["plan"]
+            )
+            st.session_state["article_v1"] = article_v1
+        if st.session_state.get("article_v1"):
+            feedback = st.text_area("Vos retours")
+            if st.button("Générer des critiques"):
+                critiques = workflow.critique_article(st.session_state["article_v1"], feedback)
+                chosen_crit = st.selectbox("Choisissez une critique", critiques)
+                st.session_state["critique"] = chosen_crit
+
+    st.header("Phase 4 : Révision")
+    if st.session_state.get("critique"):
+        if st.button("Créer la version finale"):
+            final_article = workflow.revise_article(
+                st.session_state["title"],
+                st.session_state["research"],
+                st.session_state["plan"],
+                st.session_state["article_v1"],
+                st.session_state["critique"],
+            )
+            st.session_state["final_article"] = final_article
+
+    st.header("Phase 5 : Visuels")
+    if st.session_state.get("final_article"):
+        if st.button("Générer le prompt visuel"):
+            vp = workflow.create_visual_prompt(st.session_state["final_article"])
+            st.session_state["vis_prompt"] = vp
+        if st.session_state.get("vis_prompt"):
+            st.write(st.session_state["vis_prompt"])
+            if st.button("Générer l’image"):
+                from cassiope.tools import generate_image
+
+                image_url = generate_image(st.session_state["vis_prompt"], fal_key)
+                st.session_state["image_url"] = image_url
+        if st.session_state.get("image_url"):
+            st.image(st.session_state["image_url"])
+            if st.button("Générer l’HTML"):
+                html = workflow.format_html(st.session_state["final_article"], st.session_state["image_url"])
+                st.session_state["html"] = html
+
+    if st.session_state.get("html"):
+        st.header("Article Final")
+        st.write(st.session_state["html"], unsafe_allow_html=True)
+else:
+    st.header("Éditeur de Prompts")
+    for key, text in prompts_data.items():
+        prompts_data[key] = st.text_area(key, text)
+    if st.button("Enregistrer les prompts"):
+        prompts.save_prompts(prompts_data)
+        st.success("Prompts sauvegardés")

--- a/cassiope/agents.py
+++ b/cassiope/agents.py
@@ -1,0 +1,75 @@
+from typing import List
+from agents import Agent, WebSearchTool
+from pydantic import BaseModel
+
+from .prompts import load_prompts
+
+class Plan(BaseModel):
+    sections: List[str]
+
+
+_prompts = load_prompts()
+
+# Define agents following the description
+
+generator_titres = Agent(
+    name="GénérateurTitres",
+    instructions=_prompts["generator_titres"],
+    model="gpt-4o",
+)
+
+agent_recherche = Agent(
+    name="AgentRecherche",
+    instructions=_prompts["agent_recherche"],
+    tools=[WebSearchTool()],
+    model="gpt-4o",
+)
+
+plan_agent = Agent(
+    name="GénérateurPlan",
+    instructions=_prompts["plan_agent"],
+    model="gpt-4o",
+    output_type=List[Plan],
+)
+
+redacteur_initial = Agent(
+    name="RédacteurInitial",
+    instructions=_prompts["redacteur_initial"],
+    model="gpt-4o",
+)
+
+agent_critique = Agent(
+    name="AgentCritique",
+    instructions=_prompts["agent_critique"],
+    model="gpt-4o",
+)
+
+redacteur_final = Agent(
+    name="RédacteurFinal",
+    instructions=_prompts["redacteur_final"],
+    model="gpt-4o",
+)
+
+prompt_visuel_agent = Agent(
+    name="CréateurPromptVisuel",
+    instructions=_prompts["prompt_visuel_agent"],
+    model="gpt-4o",
+)
+
+html_formatter = Agent(
+    name="FormateurHTML",
+    instructions=_prompts["html_formatter"],
+    model="gpt-4o",
+)
+
+# Map names to agents for convenience
+AGENTS = {
+    "generator_titres": generator_titres,
+    "agent_recherche": agent_recherche,
+    "plan_agent": plan_agent,
+    "redacteur_initial": redacteur_initial,
+    "agent_critique": agent_critique,
+    "redacteur_final": redacteur_final,
+    "prompt_visuel_agent": prompt_visuel_agent,
+    "html_formatter": html_formatter,
+}

--- a/cassiope/config.py
+++ b/cassiope/config.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+CONFIG_FILE = Path.home() / '.cassiope_config.json'
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "tone": "professionnel",
+    "length": "moyen",
+    "OPENAI_API_KEY": "",
+    "FAL_API_KEY": "",
+}
+
+def load_config() -> Dict[str, Any]:
+    if CONFIG_FILE.exists():
+        with CONFIG_FILE.open() as f:
+            data = json.load(f)
+    else:
+        data = DEFAULT_CONFIG.copy()
+        CONFIG_FILE.write_text(json.dumps(data, indent=2))
+    return data
+
+def save_config(cfg: Dict[str, Any]) -> None:
+    CONFIG_FILE.write_text(json.dumps(cfg, indent=2))

--- a/cassiope/prompts.py
+++ b/cassiope/prompts.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+PROMPTS_FILE = Path.home() / '.cassiope_prompts.json'
+
+DEFAULT_PROMPTS: Dict[str, str] = {
+    'generator_titres': "Générer 10 titres créatifs et professionnels pour le thème donné.",
+    'agent_recherche': (
+        "Effectuer une recherche web approfondie sur le titre sélectionné et résumer les résultats en français.") ,
+    'plan_agent': "Créer 3 plans détaillés pour l’article basé sur le titre et les recherches.",
+    'redacteur_initial': (
+        "Rédiger une première version de l’article basée sur le titre, les recherches et le plan."),
+    'agent_critique': (
+        "Analyser l’article et les retours utilisateur pour proposer 3 suggestions d’amélioration."),
+    'redacteur_final': (
+        "Réviser l’article en intégrant la critique, le titre, les recherches et le plan."),
+    'prompt_visuel_agent': (
+        "Générer un prompt visuel détaillé basé sur le contenu de l’article."),
+    'html_formatter': (
+        "Formatter l’article et les images dans un document HTML publiable avec une mise en page moderne."),
+}
+
+
+def load_prompts() -> Dict[str, str]:
+    if PROMPTS_FILE.exists():
+        try:
+            return json.loads(PROMPTS_FILE.read_text())
+        except Exception:
+            pass
+    PROMPTS_FILE.write_text(json.dumps(DEFAULT_PROMPTS, ensure_ascii=False, indent=2))
+    return DEFAULT_PROMPTS.copy()
+
+
+def save_prompts(prompts: Dict[str, str]) -> None:
+    PROMPTS_FILE.write_text(json.dumps(prompts, ensure_ascii=False, indent=2))

--- a/cassiope/tools.py
+++ b/cassiope/tools.py
@@ -1,0 +1,18 @@
+import os
+import requests
+from typing import Optional
+
+from agents import function_tool
+
+@function_tool
+def generate_image(prompt: str, fal_api_key: Optional[str] = None) -> str:
+    """Generate an image via Fal.ai and return the URL."""
+    api_key = fal_api_key or os.environ.get("FAL_API_KEY")
+    if not api_key:
+        raise ValueError("FAL_API_KEY not set")
+    url = "https://api.fal.ai/v1/images"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {"prompt": prompt, "model": "stable-diffusion-v3"}
+    response = requests.post(url, json=payload, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.json().get("image_url", "")

--- a/cassiope/workflow.py
+++ b/cassiope/workflow.py
@@ -1,0 +1,78 @@
+from typing import Dict, List
+
+from agents import Runner
+from .config import load_config, save_config
+
+from .agents import (
+    generator_titres,
+    agent_recherche,
+    plan_agent,
+    redacteur_initial,
+    agent_critique,
+    redacteur_final,
+    prompt_visuel_agent,
+    html_formatter,
+)
+
+
+def refine_title(theme: str) -> List[str]:
+    result = Runner.run_sync(generator_titres, theme)
+    return result.final_output
+
+
+def set_title(title: str) -> None:
+    cfg = load_config()
+    cfg["title"] = title
+    save_config(cfg)
+
+
+def research(title: str) -> str:
+    result = Runner.run_sync(agent_recherche, title)
+    return result.final_output
+
+
+def generate_plans(title: str, research_results: str):
+    result = Runner.run_sync(plan_agent, f"{title}\n{research_results}")
+    return result.final_output
+
+
+def draft_article(title: str, research_results: str, plan: str):
+    cfg = load_config()
+    meta = f"Tone: {cfg.get('tone')}\nLongueur: {cfg.get('length')}"
+    result = Runner.run_sync(
+        redacteur_initial,
+        f"{title}\n{plan}\n{research_results}\n{meta}",
+    )
+    return result.final_output
+
+
+def critique_article(article_v1: str, feedback: str):
+    result = Runner.run_sync(agent_critique, f"{article_v1}\n{feedback}")
+    return result.final_output
+
+
+def revise_article(title: str, research_results: str, plan: str, article_v1: str, critique: str):
+    cfg = load_config()
+    meta = f"Tone: {cfg.get('tone')}\nLongueur: {cfg.get('length')}"
+    result = Runner.run_sync(
+        redacteur_final,
+        f"{title}\n{plan}\n{research_results}\n{article_v1}\n{critique}\n{meta}",
+    )
+    return result.final_output
+
+
+def create_visual_prompt(article: str) -> str:
+    result = Runner.run_sync(prompt_visuel_agent, article)
+    return result.final_output
+
+
+def format_html(article: str, image_url: str) -> str:
+    cfg = load_config()
+    styles = (
+        "<style>body{font-family:'Roboto',sans-serif;margin:2rem;}h1{font-weigh"
+        "t:500;}img{max-width:100%;height:auto;}</style>"
+    )
+    meta = f"<p><em>Tone: {cfg.get('tone')} - Longueur: {cfg.get('length')}</em></p>"
+    content = f"{styles}<h1>{cfg.get('title','')}</h1>{meta}{article}<img src='{image_url}'>"
+    result = Runner.run_sync(html_formatter, content)
+    return result.final_output

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai
+streamlit
+requests
+openai-agents


### PR DESCRIPTION
## Summary
- expand README
- add prompts configuration and web search integration
- allow editing prompts in the UI
- store tone and length settings
- enhance article workflow with config

## Testing
- `python -m py_compile $(find . -name '*.py' -not -path './.venv/*' -not -path './docs_zip/*')`
