### PR TITLE
Implement Cassiope prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# Cassiope-3
+# Cassiope
+
+Prototype d'application de rédaction d'articles multi-agents en français. Cette application utilise l'SDK OpenAI Agents et Streamlit pour orchestrer plusieurs agents GPT‑4o. Les prompts sont éditables et les paramètres de ton et de longueur sont sauvegardés.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Utilisation
+
+Exécutez l'interface Streamlit :
+
+```bash
+streamlit run app.py
+```
+
+Ajoutez vos clés API OpenAI et Fal.ai dans le panneau latéral puis suivez les étapes.
+Une image est générée via l'API Fal.ai et intégrée à l'article final.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,122 @@
+import streamlit as st
+from cassiope import config, workflow
+
+st.set_page_config(page_title="Cassiope", page_icon="✨")
+
+# Roboto font styling
+st.markdown(
+    """
+    <style>
+    @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+    html, body, [class*='css']  {
+        font-family: 'Roboto', sans-serif;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+cfg = config.load_config()
+
+st.title("Cassiope – Rédaction d’Articles Intelligente")
+import os
+
+openai_key = st.sidebar.text_input("Clé API OpenAI", value=cfg.get("OPENAI_API_KEY"), type="password")
+fal_key = st.sidebar.text_input("Clé API Fal.ai", value=cfg.get("FAL_API_KEY"), type="password")
+
+if st.sidebar.button("Enregistrer les clés"):
+    cfg["OPENAI_API_KEY"] = openai_key
+    cfg["FAL_API_KEY"] = fal_key
+    os.environ["OPENAI_API_KEY"] = openai_key
+    os.environ["FAL_API_KEY"] = fal_key
+    config.save_config(cfg)
+    st.sidebar.success("Clés sauvegardées")
+
+with st.sidebar.expander("Paramètres de l'article"):
+    tone = st.selectbox(
+        "Ton", ["professionnel", "analytique", "inspirationnel"],
+        index=["professionnel", "analytique", "inspirationnel"].index(cfg.get("tone", "professionnel")),
+    )
+    length = st.slider("Longueur (mots)", 300, 2000, int(cfg.get("length", 800)))
+    if st.button("Enregistrer les paramètres", key="save_params"):
+        cfg["tone"] = tone
+        cfg["length"] = length
+        config.save_config(cfg)
+        st.success("Paramètres sauvegardés")
+
+prompts = config.load_prompts()
+with st.sidebar.expander("Éditeur de prompts"):
+    updated = {}
+    for name, text in prompts.items():
+        updated[name] = st.text_area(name, value=text)
+    if st.button("Enregistrer les prompts", key="save_prompts"):
+        config.save_prompts(updated)
+        st.success("Prompts sauvegardés")
+    if st.button("Restaurer par défaut", key="reset_prompts"):
+        config.save_prompts(config.DEFAULT_PROMPTS)
+        st.success("Prompts restaurés")
+
+st.header("Phase 1 : Raffinement du Thème et du Titre")
+theme = st.text_input("Thème initial")
+if st.button("Générer des titres") and theme:
+    titres = workflow.refine_title(theme)
+    chosen_title = st.radio("Choisissez un titre", titres)
+    st.session_state["title"] = chosen_title
+
+st.header("Phase 2 : Recherche et Planification")
+if st.session_state.get("title"):
+    if st.button("Lancer la recherche"):
+        research_results = workflow.research(st.session_state["title"])
+        st.session_state["research"] = research_results
+    if st.session_state.get("research"):
+        plans = workflow.generate_plans(st.session_state["title"], st.session_state["research"])
+        chosen_plan = st.selectbox("Choisissez un plan", plans)
+        st.session_state["plan"] = chosen_plan
+
+st.header("Phase 3 : Rédaction Initiale")
+if st.session_state.get("plan"):
+    if st.button("Rédiger l’article"):
+        article_v1 = workflow.draft_article(
+            st.session_state["title"], st.session_state["research"], st.session_state["plan"]
+        )
+        st.session_state["article_v1"] = article_v1
+    if st.session_state.get("article_v1"):
+        feedback = st.text_area("Vos retours")
+        if st.button("Générer des critiques"):
+            critiques = workflow.critique_article(st.session_state["article_v1"], feedback)
+            chosen_crit = st.selectbox("Choisissez une critique", critiques)
+            st.session_state["critique"] = chosen_crit
+
+st.header("Phase 4 : Révision")
+if st.session_state.get("critique"):
+    if st.button("Créer la version finale"):
+        final_article = workflow.revise_article(
+            st.session_state["title"],
+            st.session_state["research"],
+            st.session_state["plan"],
+            st.session_state["article_v1"],
+            st.session_state["critique"],
+        )
+        st.session_state["final_article"] = final_article
+
+st.header("Phase 5 : Visuels")
+if st.session_state.get("final_article"):
+    if st.button("Générer le prompt visuel"):
+        vp = workflow.create_visual_prompt(st.session_state["final_article"])
+        st.session_state["vis_prompt"] = vp
+    if st.session_state.get("vis_prompt"):
+        st.write(st.session_state["vis_prompt"])
+        if st.button("Générer l’image"):
+            from cassiope.tools import generate_image
+
+            image_url = generate_image(st.session_state["vis_prompt"], fal_key)
+            st.session_state["image_url"] = image_url
+    if st.session_state.get("image_url"):
+        st.image(st.session_state["image_url"])
+        if st.button("Générer l’HTML"):
+            html = workflow.format_html(st.session_state["final_article"], st.session_state["image_url"])
+            st.session_state["html"] = html
+
+if st.session_state.get("html"):
+    st.header("Article Final")
+    st.write(st.session_state["html"], unsafe_allow_html=True)

--- a/cassiope/__init__.py
+++ b/cassiope/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['agents', 'workflow', 'tools']

--- a/cassiope/agents.py
+++ b/cassiope/agents.py
@@ -1,0 +1,76 @@
+from typing import List
+from agents import Agent
+from pydantic import BaseModel
+
+from . import config
+from .tools import generate_image
+
+class Plan(BaseModel):
+    sections: List[str]
+
+# Load prompts from config
+PROMPTS = config.load_prompts()
+
+# Define agents following the description
+
+generator_titres = Agent(
+    name="GénérateurTitres",
+    instructions=PROMPTS.get("GénérateurTitres"),
+    model="gpt-4o",
+)
+
+agent_recherche = Agent(
+    name="AgentRecherche",
+    instructions=PROMPTS.get("AgentRecherche"),
+    tools=[],  # placeholder for web search tool
+    model="gpt-4o",
+)
+
+plan_agent = Agent(
+    name="GénérateurPlan",
+    instructions=PROMPTS.get("GénérateurPlan"),
+    model="gpt-4o",
+    output_type=List[Plan],
+)
+
+redacteur_initial = Agent(
+    name="RédacteurInitial",
+    instructions=PROMPTS.get("RédacteurInitial"),
+    model="gpt-4o",
+)
+
+agent_critique = Agent(
+    name="AgentCritique",
+    instructions=PROMPTS.get("AgentCritique"),
+    model="gpt-4o",
+)
+
+redacteur_final = Agent(
+    name="RédacteurFinal",
+    instructions=PROMPTS.get("RédacteurFinal"),
+    model="gpt-4o",
+)
+
+prompt_visuel_agent = Agent(
+    name="CréateurPromptVisuel",
+    instructions=PROMPTS.get("CréateurPromptVisuel"),
+    model="gpt-4o",
+)
+
+html_formatter = Agent(
+    name="FormateurHTML",
+    instructions=PROMPTS.get("FormateurHTML"),
+    model="gpt-4o",
+)
+
+# Map names to agents for convenience
+AGENTS = {
+    "generator_titres": generator_titres,
+    "agent_recherche": agent_recherche,
+    "plan_agent": plan_agent,
+    "redacteur_initial": redacteur_initial,
+    "agent_critique": agent_critique,
+    "redacteur_final": redacteur_final,
+    "prompt_visuel_agent": prompt_visuel_agent,
+    "html_formatter": html_formatter,
+}

--- a/cassiope/config.py
+++ b/cassiope/config.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+from .prompts import DEFAULT_PROMPTS
+
+CONFIG_FILE = Path.home() / '.cassiope_config.json'
+
+def load_config() -> Dict[str, Any]:
+    if CONFIG_FILE.exists():
+        with CONFIG_FILE.open() as f:
+            return json.load(f)
+    return {}
+
+def save_config(cfg: Dict[str, Any]) -> None:
+    CONFIG_FILE.write_text(json.dumps(cfg, indent=2))
+
+
+def load_prompts() -> Dict[str, str]:
+    cfg = load_config()
+    prompts = cfg.get("prompts") or {}
+    if not prompts:
+        prompts = DEFAULT_PROMPTS.copy()
+        cfg["prompts"] = prompts
+        save_config(cfg)
+    return prompts
+
+
+def save_prompts(prompts: Dict[str, str]) -> None:
+    cfg = load_config()
+    cfg["prompts"] = prompts
+    save_config(cfg)

--- a/cassiope/prompts.py
+++ b/cassiope/prompts.py
@@ -1,0 +1,10 @@
+DEFAULT_PROMPTS = {
+    "GénérateurTitres": "Générer 10 titres créatifs et professionnels pour le thème donné.",
+    "AgentRecherche": "Effectuer une recherche web approfondie sur le titre sélectionné et résumer les résultats en français.",
+    "GénérateurPlan": "Créer 3 plans détaillés pour l’article basé sur le titre et les recherches.",
+    "RédacteurInitial": "Rédiger une première version de l’article en suivant le plan, avec un ton professionnel.",
+    "AgentCritique": "Analyser l’article et les retours utilisateur pour proposer 3 suggestions d’amélioration.",
+    "RédacteurFinal": "Réviser l’article en intégrant la critique, le titre, les recherches et le plan.",
+    "CréateurPromptVisuel": "Générer un prompt visuel détaillé basé sur le contenu de l’article.",
+    "FormateurHTML": "Formatter l’article et les images dans un document HTML publiable en utilisant la police Roboto et en insérant l’image via &lt;img src='URL' /&gt;.",
+}

--- a/cassiope/tools.py
+++ b/cassiope/tools.py
@@ -1,0 +1,32 @@
+import os
+import requests
+from typing import Optional
+
+from agents import function_tool
+
+@function_tool
+def generate_image(prompt: str, fal_api_key: Optional[str] = None, openai_key: Optional[str] = None) -> str:
+    """Generate an image via Fal.ai and return the URL."""
+    api_key = fal_api_key or os.environ.get("FAL_API_KEY")
+    openai_api_key = openai_key or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("FAL_API_KEY not set")
+    if not openai_api_key:
+        raise ValueError("OPENAI_API_KEY not set")
+    url = "https://api.fal.ai/v1/pipelines/fal-ai/gpt-image-1/text-to-image/byok"
+    headers = {"Authorization": f"Key {api_key}"}
+    payload = {
+        "prompt": prompt,
+        "image_size": "auto",
+        "num_images": 1,
+        "quality": "auto",
+        "background": "auto",
+        "openai_api_key": openai_api_key,
+    }
+    response = requests.post(url, json=payload, headers=headers, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    try:
+        return data["images"][0]["url"]
+    except Exception:
+        return ""

--- a/cassiope/workflow.py
+++ b/cassiope/workflow.py
@@ -1,0 +1,66 @@
+from typing import Dict, List
+
+from agents import Runner
+
+from . import config
+from .agents import (
+    generator_titres,
+    agent_recherche,
+    plan_agent,
+    redacteur_initial,
+    agent_critique,
+    redacteur_final,
+    prompt_visuel_agent,
+    html_formatter,
+)
+
+
+def refine_title(theme: str) -> List[str]:
+    result = Runner.run_sync(generator_titres, theme)
+    return result.final_output
+
+
+def research(title: str) -> str:
+    result = Runner.run_sync(agent_recherche, title)
+    return result.final_output
+
+
+def generate_plans(title: str, research_results: str):
+    result = Runner.run_sync(plan_agent, f"{title}\n{research_results}")
+    return result.final_output
+
+
+def draft_article(title: str, research_results: str, plan: str):
+    cfg = config.load_config()
+    tone = cfg.get("tone", "professionnel")
+    length = cfg.get("length", 800)
+    input_data = f"Ton: {tone}\nLongueur: {length}\nTitre: {title}\nPlan: {plan}\nRecherches: {research_results}"
+    result = Runner.run_sync(redacteur_initial, input_data)
+    return result.final_output
+
+
+def critique_article(article_v1: str, feedback: str):
+    result = Runner.run_sync(agent_critique, f"{article_v1}\n{feedback}")
+    return result.final_output
+
+
+def revise_article(title: str, research_results: str, plan: str, article_v1: str, critique: str):
+    cfg = config.load_config()
+    tone = cfg.get("tone", "professionnel")
+    length = cfg.get("length", 800)
+    input_data = (
+        f"Ton: {tone}\nLongueur: {length}\nTitre: {title}\nPlan: {plan}\nRecherche: {research_results}\nArticle:\n{article_v1}\nCritique: {critique}"
+    )
+    result = Runner.run_sync(redacteur_final, input_data)
+    return result.final_output
+
+
+def create_visual_prompt(article: str) -> str:
+    result = Runner.run_sync(prompt_visuel_agent, article)
+    return result.final_output
+
+
+def format_html(article: str, image_url: str) -> str:
+    content = f"Article:\n{article}\nImage:\n{image_url}"
+    result = Runner.run_sync(html_formatter, content)
+    return result.final_output

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai
+streamlit
+requests
+openai-agents


### PR DESCRIPTION
## Summary
- add Streamlit UI for Cassiope multi-agent workflow
- implement agent definitions and workflow functions
- provide simple Fal.ai tool and configuration helpers
- document setup and usage
- add prompt editing and tone/length settings
- update Fal.ai integration

## Testing
- `python -m py_compile $(find . -name '*.py' -not -path './.venv/*')`